### PR TITLE
Force pyopenssl upgrade

### DIFF
--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -21,6 +21,8 @@ dependencies:
   - jupyter-server-proxy
   - jupyterlab-git
   - jupyterlab-code-snippets
+  # updating cryptography
+  - pyopenssl
   # extras
   - pip
   - pip:


### PR DESCRIPTION
In the lab, an error while loading csv occurs:

```File /opt/conda/lib/python3.8/site-packages/OpenSSL/crypto.py:3268
   3248 load_pkcs12 = utils.deprecated(
   3249     load_pkcs12,
   3250     __name__,
   (...)
   3255     DeprecationWarning,
   3256 )
   3259 # There are no direct unit tests for this initialization.  It is tested
   3260 # indirectly since it is necessary for functions like dump_privatekey when
   3261 # using encryption.
   (...)
   3266 # OpenSSL library (and is linked against the same one that cryptography is
   3267 # using)).
-> 3268 _lib.OpenSSL_add_all_algorithms()
   3270 # This is similar but exercised mainly by exception_from_error_queue.  It calls
   3271 # both ERR_load_crypto_strings() and ERR_load_SSL_strings().
   3272 _lib.SSL_load_error_strings()

AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'```

Should be due to incompatibility between cryptography and pyopenssl. The version on the image is very old.

https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss
https://github.com/pyca/cryptography/issues/7959