### PR TITLE
Hotfix/pin-python-version

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/jupyter/docker-stacks
 # https://hub.docker.com/u/jupyter/
-FROM jupyter/base-notebook:python-3.8
+FROM jupyter/base-notebook:python-3.8.13
 
 USER root
 

--- a/docker/pyscript/Dockerfile
+++ b/docker/pyscript/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim
+FROM python:3.8.17-slim
 
 USER root
 


### PR DESCRIPTION
* pin to v3.8.17 for Python scripts
* pin to v3.8.13 (latest available) for Jupyterlab