### PR TITLE
Noos 447/upgrade-node-version

### DIFF
--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update && \
 
 # Install Node.js
 # ---------------
-ARG NODE_VERSION="v16.13.1"
+ARG NODE_VERSION="v18.18.0"
 RUN curl -sSL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" | \
 	tar -xJ -C /usr/local --strip-components=1
 
 # Install JavaScript package manager
 # ----------------------------------
-ARG YARN_VERSION="v1.22.17"
+ARG YARN_VERSION="v1.22.19"
 RUN npm install --global yarn@${YARN_VERSION}
 
 # Install Python package managers


### PR DESCRIPTION
Update Node version to v18

**JIRA Reference**: [NOOS-447](https://noosenergy.atlassian.net/browse/NOOS-447)

[NOOS-447]: https://noosenergy.atlassian.net/browse/NOOS-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ