### PR TITLE
NOOS-517/circleci-x-platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     executor: noos-ci/default
     steps:
       - checkout
-      - noos-ci/docker_build_image:
+      - noos-ci/docker_buildx_image:
           registry_provider: docker
           image_context: ./docker/circleci
           image_name: circleci

--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -42,7 +42,7 @@ RUN pip install --upgrade pip && \
 
 # Install Noos CI/CD SDKs
 # -----------------------
-ARG NOOSINV_VERSION="0.0.15"
+ARG NOOSINV_VERSION="0.0.17"
 ARG NOOSTF_VERSION="0.0.8"
 RUN pip install noos-inv==$NOOSINV_VERSION noos-tf==$NOOSTF_VERSION
 


### PR DESCRIPTION
# Description
* Allow ARM64/AMD64 dual platform for the CircleCI image

**JIRA Reference:** [NOOS-517](https://noosenergy.atlassian.net/browse/NOOS-517)

[NOOS-517]: https://noosenergy.atlassian.net/browse/NOOS-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ