### PR TITLE
NOOS-517/revert-circleci-x-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     executor: noos-ci/default
     steps:
       - checkout
-      - noos-ci/docker_buildx_image:
+      - noos-ci/docker_build_image:
           registry_provider: docker
           image_context: ./docker/circleci
           image_name: circleci


### PR DESCRIPTION
# Description
* Reverting x-platform build on CircleCI image due to a non-compatibility on Gecko driver

**JIRA Reference:** [NOOS-517](https://noosenergy.atlassian.net/browse/NOOS-517)

[NOOS-517]: https://noosenergy.atlassian.net/browse/NOOS-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ