### PR TITLE
NOOS-874/install-latest-backports-package-via-conda

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -41,4 +41,7 @@ RUN rm -rf /tmp/* && \
 RUN jupyter lab clean && \
     jupyter lab build --dev-build=False
 
+# Workaround for NOOS-874
+RUN conda install backports
+
 USER $NB_UID


### PR DESCRIPTION
# Description

Use conda instead of mamba to install latest version of backports package.

<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-874](https://noosenergy.atlassian.net/browse/NOOS-874)


[NOOS-874]: https://noosenergy.atlassian.net/browse/NOOS-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ