### PR TITLE
NOOS-881/reduce-jupyterlab-image-size

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -1,14 +1,18 @@
+# -----------
+# Build stage
+# -----------
+
 # https://github.com/jupyter/docker-stacks
 # https://hub.docker.com/u/jupyter/
-FROM jupyter/base-notebook:python-3.11.4
+FROM jupyter/base-notebook:python-3.11.4 as builder
 
 USER root
 
 # Install Apt packages
 # --------------------
-COPY package.list /tmp/
+COPY build_package.list /tmp/
 RUN apt-get update && \
-    grep -vE '^#' /tmp/package.list | xargs apt-get install -y && \
+    grep -vE '^#' /tmp/build_package.list | xargs apt-get install -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/fontconfig/*
 
@@ -28,20 +32,41 @@ COPY lab/data/. ${CONDA_DIR}/share/jupyter/lab/settings
 # ------------------------------------------------------------------
 COPY config_extensions/. ${HOME}/.jupyter
 
-# Cleanup
-# -------
-RUN rm -rf /tmp/* && \
-    rm -rf ${HOME}/work ${HOME}/.cache ${HOME}/.npm ${HOME}/.yarn && \
-    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
-    find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete && \
-    fix-permissions $CONDA_DIR
-
 # Build Lab extensions
 # --------------------
-RUN jupyter lab clean && \
-    jupyter lab build --dev-build=False
+RUN jupyter lab build --dev-build=False && \
+    jupyter lab clean 
 
 # Workaround for NOOS-874
+# -----------------------
 RUN conda install backports
+
+# Cleanup
+# -------
+RUN find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
+    find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete && \
+    fix-permissions ${CONDA_DIR} && \
+    fix-permissions ${HOME}/.jupyter
+
+
+# -----------
+# Final stage
+# -----------
+
+FROM jupyter/base-notebook:python-3.11.4
+
+USER root
+
+COPY final_package.list /tmp/
+RUN apt-get update && \
+    grep -vE '^#' /tmp/final_package.list | xargs apt-get install -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/fontconfig/*
+
+# Make sure we do not keep old folders/files from the jupyterlab/base-notebook image 
+# (some existing libs were reinstalled with another version by mamba during the build stage)
+RUN rm -rf ${CONDA_DIR} && rm -rf ${HOME}/.jupyter
+COPY --from=builder ${CONDA_DIR} ${CONDA_DIR}
+COPY --from=builder ${HOME}/.jupyter ${HOME}/.jupyter
 
 USER $NB_UID

--- a/docker/jupyterlab/build_package.list
+++ b/docker/jupyterlab/build_package.list
@@ -1,10 +1,6 @@
 # --- Jupyter dependencies ---
 build-essential
 python3-dev
-# --- nbconvert dependencies ---
-texlive-xetex
-texlive-fonts-recommended
-texlive-plain-generic
 # --- common utilities ---
 git
 tzdata

--- a/docker/jupyterlab/final_package.list
+++ b/docker/jupyterlab/final_package.list
@@ -1,0 +1,5 @@
+# --- common utilities ---
+git
+tzdata
+unzip
+jq


### PR DESCRIPTION
# Description

Reduce the size of the jupyterlab image


<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-881](https://noosenergy.atlassian.net/browse/NOOS-881)

# Changes

- [x] Remove `texlive` -related system packages (requirement for converting notebooks to PDF with  nbconvert  but we are not using it)
- [x] Convert to a multi-stage build
- [x] Apply the `fix-permissions` scripts during the build stage only

[NOOS-881]: https://noosenergy.atlassian.net/browse/NOOS-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ