### PR TITLE
Noos 881/reduce-jupyterlab-image-size (v2)

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -16,10 +16,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/fontconfig/*
 
+USER ${NB_UID}
+
 # Install Conda packages
 # ----------------------
 COPY environment.yml /tmp/
-RUN mamba env update -q -f /tmp/environment.yml && \
+RUN umask 002 && \
+    mamba env update -q -f /tmp/environment.yml && \
     mamba clean --all -f -y
 
 # Configure Lab extensions
@@ -34,11 +37,13 @@ COPY config_extensions/. ${HOME}/.jupyter
 
 # Build Lab extensions
 # --------------------
-RUN jupyter lab build --dev-build=False && \
+RUN umask 002 && \
+    jupyter lab build --dev-build=False && \
     jupyter lab clean 
 
 # Cleanup
 # -------
+USER root
 RUN find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
     find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete && \
     fix-permissions ${CONDA_DIR} && \
@@ -65,4 +70,4 @@ RUN rm -rf ${CONDA_DIR} && rm -rf ${HOME}/.jupyter
 COPY --from=builder ${CONDA_DIR} ${CONDA_DIR}
 COPY --from=builder ${HOME}/.jupyter ${HOME}/.jupyter
 
-USER $NB_UID
+USER ${NB_UID}

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -33,7 +33,7 @@ COPY lab/data/. ${CONDA_DIR}/share/jupyter/lab/settings
 
 # Configure Jupyterlab extensions (nbconvert & jupyterlab-templates)
 # ------------------------------------------------------------------
-COPY config_extensions/. ${HOME}/.jupyter
+COPY config_extensions/. /home/${NB_USER}/.jupyter
 
 # Build Lab extensions
 # --------------------
@@ -47,7 +47,7 @@ USER root
 RUN find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
     find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete && \
     fix-permissions ${CONDA_DIR} && \
-    fix-permissions ${HOME}/.jupyter
+    fix-permissions /home/${NB_USER}/.jupyter
 
 
 # -----------
@@ -66,8 +66,8 @@ RUN apt-get update && \
 
 # Make sure we do not keep old folders/files from the jupyterlab/base-notebook image 
 # (some existing libs were reinstalled with another version by mamba during the build stage)
-RUN rm -rf ${CONDA_DIR} && rm -rf ${HOME}/.jupyter
+RUN rm -rf ${CONDA_DIR} && rm -rf /home/${NB_USER}/.jupyter
 COPY --from=builder ${CONDA_DIR} ${CONDA_DIR}
-COPY --from=builder ${HOME}/.jupyter ${HOME}/.jupyter
+COPY --from=builder /home/${NB_USER}/.jupyter /home/${NB_USER}/.jupyter
 
 USER ${NB_UID}

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -4,7 +4,7 @@
 
 # https://github.com/jupyter/docker-stacks
 # https://hub.docker.com/u/jupyter/
-FROM jupyter/base-notebook:python-3.11.4 as builder
+FROM quay.io/jupyter/base-notebook:python-3.11.9 as builder
 
 USER root
 
@@ -37,10 +37,6 @@ COPY config_extensions/. ${HOME}/.jupyter
 RUN jupyter lab build --dev-build=False && \
     jupyter lab clean 
 
-# Workaround for NOOS-874
-# -----------------------
-RUN conda install backports
-
 # Cleanup
 # -------
 RUN find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
@@ -53,7 +49,7 @@ RUN find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
 # Final stage
 # -----------
 
-FROM jupyter/base-notebook:python-3.11.4
+FROM quay.io/jupyter/base-notebook:python-3.11.9
 
 USER root
 

--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -2,24 +2,25 @@ name: base
 channels:
   - conda-forge
 dependencies:
+  - nodejs>14 # Needed to have a newer version of nodejs for `jupyter lab build` 
   # metapackages
   - nomkl
   # enforcing numpy 1.*
   - numpy<2.0
   # z2jh setup
-  - notebook>=6.0.0
-  - jupyterlab>=3.0.0
-  - jupyterhub==3.0.0
+  - notebook
+  - jupyterlab<4 # Force downgrade to jupyterlab 3
+  - jupyterhub
   # debugging
   - xeus-python
   # plotting
   - matplotlib
   - plotly
-  - dash>=2,<2.10
-  - ipywidgets>=7.6
-  - ipykernel>=6
+  - dash
+  - ipywidgets
+  - ipykernel
   # extensions
-  - jupyter-dash
+  - jupyterlab_pygments<0.3 # jupyterlab>4 needed for 0.3+ 
   - jupyter-server-proxy
   - jupyterlab-git
   - jupyterlab-code-snippets

--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -16,10 +16,11 @@ dependencies:
   # plotting
   - matplotlib
   - plotly
-  - dash
+  - dash>=2,<2.10
   - ipywidgets
   - ipykernel
   # extensions
+  - jupyter-dash
   - jupyterlab_pygments<0.3 # jupyterlab>4 needed for 0.3+ 
   - jupyter-server-proxy
   - jupyterlab-git


### PR DESCRIPTION
# Description

Follow-up on https://github.com/noosenergy/noos-docker-images/pull/130
Reduce the size of the jupyterlab image


<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-881](https://noosenergy.atlassian.net/browse/NOOS-881)

# Changes

- [x] Switch to base-notebook:python-3.11.9 image (to avoid our previous issue with mamba bug in package resolution for `backports`)  and fix verson conflicts. We couldn't upgrade to `jupyterlab 4` because the `code-snippet` extension is only available for `jupyter < 4`
- [ ] Remove the `jupyterlab-dash` extension and upgrade `dash` to newer version that already includes the extension  
- [x] Install conda pacakges directly with the adequate group owner & permissions to speed up the `fix-permissions` script

[NOOS-881]: https://noosenergy.atlassian.net/browse/NOOS-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ