### PR TITLE
hotfix/add-uvx-to-circleci-image

### DIFF
--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -37,6 +37,7 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV POETRY_HOME=/home/circleci/.poetry
 ENV UV_CACHE_DIR=./.uv-cache
 COPY --from=ghcr.io/astral-sh/uv:0.4.1 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.4.1 /uvx /usr/local/bin/uvx
 RUN pip install --upgrade pip && \
     pip install pipenv==$PIPENV_RELEASE && \
     curl -sSL "https://install.python-poetry.org" | \


### PR DESCRIPTION
Add `uvx` binary to circle image (in addition to `uv`)

# Why

Previous installation method via `pip` installed both the `uv` and `uvx` binaries. Our `COPY --from` replacement only copied the `uv` binary. This PR adds the `uvx` binary as well.

`uvx` is currenlty used in build & publish commands in `noosinv` when choosing the `uv` installer. Won't be necessary in the future though, because `uv` is already working on implementing those commands directly inside `uv`. 