### PR TITLE
NOOS-892/add-jupyterai

### DIFF
--- a/docker/jupyterlab/config_extensions/jupyter_jupyter_ai_config.json
+++ b/docker/jupyterlab/config_extensions/jupyter_jupyter_ai_config.json
@@ -1,0 +1,5 @@
+{
+    "AiExtension": {
+        "allowed_providers": ["openai", "openai-chat", "anthropic", "anthropic-chat"]
+    }
+}

--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -9,24 +9,25 @@ dependencies:
   - numpy<2.0
   # z2jh setup
   - notebook
-  - jupyterlab<4 # Force downgrade to jupyterlab 3
+  - jupyterlab
   - jupyterhub
   # plotting
   - matplotlib
   - plotly
-  - dash>=2,<2.10
+  - dash<3.0
   - ipywidgets
   - ipykernel
   # extensions
-  - jupyter-dash
-  - jupyterlab_pygments<0.3 # jupyterlab>4 needed for 0.3+ 
+  - jupyterlab_pygments
   - jupyter-server-proxy
   - jupyterlab-git
-  - jupyterlab-code-snippets
-  - jupyterlab_templates<0.5 # jupyterlab>4 needed for 0.5+
+  - jupyterlab_templates
+  - jupyter-ai
+  - langchain-openai  # Needed for jupyter-ai OpenAI models
+  - langchain-anthropic # Needed for jupyter-ai Anthropic models
   # updating cryptography
   - pyopenssl
   # extras
   - pip
   - pip:
-    - jupyterlab-spreadsheet-editor<0.7 # jupyterlab>4 needed for 0.7+
+    - jupyterlab-spreadsheet-editor


### PR DESCRIPTION
# Description

Upgrade to Jupyterlab v4 and add jupyter-ai extension

# Changes

* [x] Upgrade to jupyterlab v4
* [x] Add jupyter-ai extension
* [x] Update version of previously incompatible extensions with jupyter v4
* [x] Remove the code-snippets extension that is not compatible with jupyter v4
* [x] Update dash & plotly that already contain the corresponding jupyter extension

Note: we now have 2 error messages upon jupyter lab startup, but those could be safely ignored according to those sources:
* Plotly/jupyter-dash extension: https://github.com/jupyterlab/jupyterlab/issues/14590#issuecomment-2266655479
* Jupyter-ai extension: https://github.com/jupyterlab/jupyter-ai/issues/839