### PR TITLE
NOOS-892/add-jupyterai-v2

### DIFF
--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -23,11 +23,11 @@ dependencies:
   - jupyterlab-git
   - jupyterlab_templates
   - jupyter-ai
-  - langchain-openai  # Needed for jupyter-ai OpenAI models
-  - langchain-anthropic # Needed for jupyter-ai Anthropic models
   # updating cryptography
   - pyopenssl
   # extras
   - pip
   - pip:
     - jupyterlab-spreadsheet-editor
+    - langchain-openai  # Needed for jupyter-ai OpenAI models
+    - langchain-anthropic # Needed for jupyter-ai Anthropic models


### PR DESCRIPTION
# Description

Install `langchain-openai` and `langchain-anthropic` packages via pip instead of mamba.

Those packages depend on `jiter` whose build is not available on linux arm architecture on mamba/conda (see [here](https://anaconda.org/conda-forge/jiter/files))

Hope it will be ok if we install them via pip instead (the linux arm wheel is available, see [here](https://pypi.org/project/jiter/0.5.0/#files ))