### PR TITLE
NOOS-892/add-jupyterai-v3

### DIFF
--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -22,12 +22,12 @@ dependencies:
   - jupyter-server-proxy
   - jupyterlab-git
   - jupyterlab_templates
-  - jupyter-ai
   # updating cryptography
   - pyopenssl
   # extras
   - pip
   - pip:
     - jupyterlab-spreadsheet-editor
+    - jupyter-ai
     - langchain-openai  # Needed for jupyter-ai OpenAI models
     - langchain-anthropic # Needed for jupyter-ai Anthropic models


### PR DESCRIPTION
# Descripton

Installing all jupyter-ai related packages via pip to avoid a mix between pip and conda (version conflicts between `langchain-*` packages otherwise).