### PR TITLE
hotfix/add-jupyterlab-retrieve-base-url

### DIFF
--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -31,3 +31,4 @@ dependencies:
     - jupyter-ai
     - langchain-openai  # Needed for jupyter-ai OpenAI models
     - langchain-anthropic # Needed for jupyter-ai Anthropic models
+    - jupyterlab-retrieve-base-url # Needed to infer proxy settings inside the hub


### PR DESCRIPTION
# Description

Add a jupyterlab extension to retrieve the base url (needed to dynamically configure the proxy settings): https://github.com/mthiboust/jupyterlab-retrieve-base-url

Will not be necessary anymore when `dash` will release a new version compatible with `jupyter v4`