### PR TITLE
NOOS-830/dbbackup-skip-tables-content

### DIFF
--- a/docker/dbbackup/docker-entrypoint.sh
+++ b/docker/dbbackup/docker-entrypoint.sh
@@ -14,6 +14,7 @@ PGDB=${DATABASE_NAME:-postgres}
 PGUSER=${DATABASE_USER:-postgres}
 PGHOST=${DATABASE_HOST:-localhost}
 PGPORT=${DATABASE_PORT:-5432}
+PGIGNORE=${DATABASE_BACKUP_IGNORE_REGEX:-""}
 # https://www.postgresql.org/docs/10/libpq-envars.html
 export PGPASSWORD=$DATABASE_PASSWORD
 
@@ -22,7 +23,7 @@ case "$1" in
     backup-to-s3)
         echo "$(date) - dumping ${PGDB} from host: ${PGHOST}"
         TMP_FILE="$(date +%Y-%m-%d).sql.gz"
-        pg_dump -d $PGDB -p $PGPORT -U $PGUSER -h $PGHOST | gzip > $TMP_FILE
+        pg_dump -d $PGDB -p $PGPORT -U $PGUSER -h $PGHOST --exclude-table-data=$PGIGNORE -- | gzip > $TMP_FILE
 
         echo "$(date) - uploading file ${TMP_FILE} to ${DATABASE_BUCKET}"
         S3_URL="s3://${DATABASE_BUCKET}/${PGDB}/${TMP_FILE}"


### PR DESCRIPTION
# Description
Add optional environment variable to skip some tables content with a regex.

Example:
`DATABASE_BACKUP_IGNORE_REGEX="meters_*|weather_series_*"`

<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-830](https://noosenergy.atlassian.net/browse/NOOS-830)


[NOOS-830]: https://noosenergy.atlassian.net/browse/NOOS-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ