### PR TITLE
hotfix/jupyterlab-base-kernel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ filters:
 # ----------------
 
 orbs:
-  noos-ci: noosenergy/noos-ci@0.2.3
+  noos-ci: noosenergy/noos-ci@0.4.0
 
 # -------------
 # Pipeline jobs
@@ -64,6 +64,7 @@ jobs:
           image_context: ./docker/jupyterlab
           image_name: jupyterlab
           image_tag: ${CIRCLE_SHA1}
+          no_output_timeout: 30m
 
   build_image_pyscript:
     executor: noos-ci/default


### PR DESCRIPTION
# Description

* Extend CircleCI timeout limit during the build of the JupyterLab base kernel

https://app.circleci.com/pipelines/github/noosenergy/noos-docker-images/553/workflows/c0752e30-2a7d-45ad-9d14-55dec31c6530/jobs/797