### PR TITLE
hotfix/jupyterlab-base-kernel-v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
 
   build_image_jupyterlab:
     executor: noos-ci/default
+    resource_class: large
     steps:
       - checkout
       - noos-ci/docker_buildx_image:


### PR DESCRIPTION
# Description

* Migrate Docker build for the base JupyterLab image to CircleCI large instances
