### PR TITLE
hotfix/increase-timeout-for-jupyterlab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           image_context: ./docker/jupyterlab
           image_name: jupyterlab
           image_tag: ${CIRCLE_SHA1}
-          no_output_timeout: 30m
+          no_output_timeout: 45m
 
   build_image_pyscript:
     executor: noos-ci/default


### PR DESCRIPTION
# Description

Increase timeout for jupyterlab image 

The long duration of the ARM build often hits timeouts. This PR raises the `no_output_timeout` from 30 to 45 minutes.