### PR TITLE
hotfix/remove-jupyterlab-retrieve-base-url

### DIFF
--- a/docker/jupyterlab/environment.yml
+++ b/docker/jupyterlab/environment.yml
@@ -32,4 +32,3 @@ dependencies:
     - jupyter-ai
     - langchain-openai  # Needed for jupyter-ai OpenAI models
     - langchain-anthropic # Needed for jupyter-ai Anthropic models
-    - jupyterlab-retrieve-base-url # Needed to infer proxy settings inside the hub


### PR DESCRIPTION
# Description

Remove the custom jupyterlab retrieve base url extension since it has been included in dash 18.2 (release available on both pypi & conda-forge).

References:
* Previous PR adding this extension: https://github.com/noosenergy/noos-docker-images/pull/140
* Dash 18.2 release: https://github.com/plotly/dash/releases/tag/v2.18.2
* PR merged on Dash official repo: https://github.com/plotly/dash/pull/3028