### PR TITLE
NOOS-1193/circleci-img-update-noosinv-version

### DIFF
--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -88,7 +88,7 @@ RUN pip install --upgrade pip && \
 
 # Install Noos CI/CD SDKs
 # -----------------------
-ARG NOOSINV_VERSION="0.2.3"
+ARG NOOSINV_VERSION="0.2.4"
 ARG NOOSTF_VERSION="0.0.9"
 RUN pip install noos-inv==$NOOSINV_VERSION noos-tf==$NOOSTF_VERSION
 

--- a/docker/circleci/mozilla-firefox
+++ b/docker/circleci/mozilla-firefox
@@ -1,3 +1,0 @@
-Package: *
-Pin: release o=LP-PPA-mozillateam
-Pin-Priority: 1001


### PR DESCRIPTION
# Description
Use latest version of `noos-invoke` in circleci docker image

Related to noos-invoke [PR #61](https://github.com/noosenergy/noos-invoke/pull/61)
`noosinv v0.2.4` adds more build platforms to `docker buildx`, including `linux/arm64`. 

<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-1193](https://noosenergy.atlassian.net/browse/NOOS-1193)


[NOOS-1193]: https://noosenergy.atlassian.net/browse/NOOS-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ