### PR TITLE
hotfix/add-noosinv-bash-completetion-to-circleci-image

### DIFF
--- a/docker/circleci/Dockerfile
+++ b/docker/circleci/Dockerfile
@@ -58,6 +58,7 @@ RUN pip install --upgrade pip && \
 ARG NOOSINV_VERSION="0.0.19"
 ARG NOOSTF_VERSION="0.0.9"
 RUN pip install noos-inv==$NOOSINV_VERSION noos-tf==$NOOSTF_VERSION
+RUN noosinv --print-completion-script=bash >> /home/circleci/.bashrc
 
 WORKDIR /home/circleci/project
 USER circleci


### PR DESCRIPTION
# Description
Add bash completion for noosinv to circleci docker image