### PR TITLE
Add Deployment section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,6 @@
 
 <!--- Add JIRA reference here -->
 **JIRA Reference**: [NOOS-<num>](https://noosenergy.atlassian.net/browse/NOOS-<num>)
+
+## Deployment
+Once merged, check deployment on [circleci](https://app.circleci.com/pipelines/github/noosenergy/noos-docker-images)


### PR DESCRIPTION
# Description

Hotfix change - add standard Deployment section to pull request template with CircleCI link to maintain consistency across repositories.

## Deployment
Once merged, check deployment on [circleci](https://app.circleci.com/pipelines/github/noosenergy/noos-docker-images)