### PR TITLE
hotfix/increase-minor-python-version-for-jupyterlab-image

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -4,7 +4,7 @@
 
 # https://github.com/jupyter/docker-stacks
 # https://hub.docker.com/u/jupyter/
-FROM quay.io/jupyter/base-notebook:python-3.12.8 as builder
+FROM quay.io/jupyter/base-notebook:python-3.12.11 as builder
 
 USER root
 
@@ -54,7 +54,7 @@ RUN find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
 # Final stage
 # -----------
 
-FROM quay.io/jupyter/base-notebook:python-3.12.8
+FROM quay.io/jupyter/base-notebook:python-3.12.11
 
 USER root
 


### PR DESCRIPTION
# Description
Use python 3.12.11 for jupyter base image

## Deployment
Once merged, check deployment on [circleci](https://app.circleci.com/pipelines/github/noosenergy/noos-docker-images)
